### PR TITLE
Disable-DbsBrowser

### DIFF
--- a/public/Disable-DbsBrowser.ps1
+++ b/public/Disable-DbsBrowser.ps1
@@ -54,7 +54,7 @@ function Disable-DbsBrowser {
                 }
             }
 
-            if ($instances.Count -eq 0) {
+            if ($instanceNames.Count -eq 0) {
                 Stop-DbaService -ComputerName $Computer -Type "Browser"
                 Set-Service -ComputerName $Computer -DisplayName "Browser" -StartupType "Disabled"
             }

--- a/public/Disable-DbsBrowser.ps1
+++ b/public/Disable-DbsBrowser.ps1
@@ -41,13 +41,27 @@ function Disable-DbsBrowser {
 
     process {
         foreach ($Computer in $ComputerName) {
+            $instanceNames = @()
+
             $instances = Get-DbaService -ComputerName $Computer -Type "Engine" -Credential $Crendential
 
-            $instanceNames = $instances | Where-Object InstanceName -ne "MSSQLSERVER"
+            ForEach ($instance in $instances) {
+                if ($instance.InstanceName -ne "MSSQLSERVER") {
+                    $instanceName = [pscustomobject] @{
+                        InstanceName = $instance.InstanceName
+                    }
+                    $instanceNames += $instanceName
+                }
+            }
 
-            if (@($instanceNames).Count -eq 0) {
+            if ($instances.Count -eq 0) {
                 Stop-DbaService -ComputerName $Computer -Type "Browser"
                 Set-Service -ComputerName $Computer -DisplayName "Browser" -StartupType "Disabled"
+            }
+            else {
+                ForEach ($name in $instanceNames) {
+                    Write-Message "The Browser was not disabled because instance $($name.InstanceName) exist."
+                }
             }
         }
     }

--- a/public/Disable-DbsBrowser.ps1
+++ b/public/Disable-DbsBrowser.ps1
@@ -1,0 +1,54 @@
+function Disable-DbsBrowser {
+    <#
+        .SYNOPSIS
+            Disable and stop broswer service
+
+        .DESCRIPTION
+            Disable and stop broswer service on computers with no named instances
+
+        .PARAMETER ComputerName
+            The SQL Server (or server in general) that you're connecting to. This command handles named instances.
+
+        .PARAMETER Credential
+            Credential object used to connect to the computer as a different user.
+
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+        .NOTES
+            Tags: DISA, STIG
+            Author: Tracy Boggiano (@TracyBoggiano), databasesuperhero.com
+            Copyright: (c) 2010 by Chrissy LeMaire, licensed under MIT
+            License: MIT https://opensource.org/licenses/MITl
+
+        .EXAMPLE
+            PS C:\> Disable-DbsBrowser -ComputerName Sql2016
+            Disables and stops Browser service is not named instances exist
+
+        .LINK
+        https://dbadisa.readthedocs.io/en/latest/functions/Disable-DbsBrowser/
+    #>
+
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
+    param (
+        [parameter(Mandatory, ValueFromPipeline, Position = 0)]
+        [string[]]$ComputerName,
+        [PSCredential]$Credential,
+        [switch]$EnableException
+    )
+
+    process {
+        foreach ($Computer in $ComputerName) {
+            $instances = Get-DbaService -ComputerName $Computer -Type "Engine" -Credential $Crendential
+
+            $instanceNames = $instances | Where-Object InstanceName -ne "MSSQLSERVER"
+
+            if (@($instanceNames).Count -eq 0) {
+                Stop-DbaService -ComputerName $Computer -Type "Browser"
+                Set-Service -ComputerName $Computer -DisplayName "Browser" -StartupType "Disabled"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Disable Browser service is only a default instance of SQL Server is installed on SQL Server.

PSScriptAnzalyzer as a couple of warnings though.

- The command 'Set-Service' is not available by default in PowerShell version '6.1.3' on platform 'Ubuntu 18.04.2 LTS'
- The parameter 'ComputerName' is not available for command 'Set-Service' by default in PowerShell version '6.1.3' on platform 'Microsoft Windows 10.0.17763 '

So for the first one I don't know if we need to add a test for the OS, or I need to learn PowerShell Linux commands.  The second I just don't know.
